### PR TITLE
re #36 ensure that the flyweight object "SchemaCurie" is serialized correctly

### DIFF
--- a/CHANGELOG-1.x.md
+++ b/CHANGELOG-1.x.md
@@ -2,6 +2,11 @@
 This changelog references the relevant changes done in 1.x versions.
 
 
+## v1.1.3
+* issue #36: BUG :: In `MessageRef`, when using php serialization a MessageRef doesn't always restore curies correctly.
+  This may have been the culprit for issue #34.
+
+
 ## v1.1.2
 * issue #34: BUG :: MessageRef from string fails when no tag is supplied.
 * Extended `\JsonSerializable` in `Gdbots\Pbj\WellKnown\Identifier` since we implement it on all identifiers anyways.


### PR DESCRIPTION
ensure that the flyweight object "SchemaCurie" is serialized to a string on __sleep and then restored back to an instance of "SchemaCurie" upon wakeup.

this fixes a bug where the unserializing of a message that contains a "MessageRef" doesn't always work because you can't serialize static members and instances.  nor would you want to.