### PR TITLE
v2.2.0

### DIFF
--- a/CHANGELOG-2.x.md
+++ b/CHANGELOG-2.x.md
@@ -2,6 +2,10 @@
 This changelog references the relevant changes done in 2.x versions.
 
 
+## v2.2.0
+* Optimize the `MessageResolver` by creating a manifest with all of the classes and mixins so no messages have to be instantiated when using `findOneUsingMixin` or `findAllUsingMixin` is executed.
+
+
 ## v2.1.5
 * Allow `IdentifierType` to be 255 bytes, same as `StringType`.
 

--- a/CHANGELOG-2.x.md
+++ b/CHANGELOG-2.x.md
@@ -3,7 +3,8 @@ This changelog references the relevant changes done in 2.x versions.
 
 
 ## v2.2.0
-* Optimize the `MessageResolver` by creating a manifest with all of the classes and mixins so no messages have to be instantiated when using `findOneUsingMixin` or `findAllUsingMixin` is executed.
+* Optimize the `MessageResolver` by using a manifest with all of the classes and mixins so no messages have to be instantiated when using `findOneUsingMixin` or `findAllUsingMixin` to find out if they have the given mixin.
+* Comment out the logic that includes fields on serialized or marshaled objects when field is null.
 
 
 ## v2.1.5

--- a/src/AbstractMixin.php
+++ b/src/AbstractMixin.php
@@ -30,17 +30,17 @@ abstract class AbstractMixin implements Mixin, ToArray, \JsonSerializable
     /**
      * {@inheritdoc}
      */
-    final public static function findOne($inPackage = null, $inCategory = null)
+    final public static function findOne()
     {
-        return MessageResolver::findOneUsingMixin(static::create(), $inPackage, $inCategory);
+        return MessageResolver::findOneUsingMixin(static::create());
     }
 
     /**
      * {@inheritdoc}
      */
-    final public static function findAll($inPackage = null, $inCategory = null)
+    final public static function findAll()
     {
-        return MessageResolver::findAllUsingMixin(static::create(), $inPackage, $inCategory);
+        return MessageResolver::findAllUsingMixin(static::create());
     }
 
     /**

--- a/src/Exception/MoreThanOneMessageForMixin.php
+++ b/src/Exception/MoreThanOneMessageForMixin.php
@@ -2,42 +2,41 @@
 
 namespace Gdbots\Pbj\Exception;
 
-use Gdbots\Pbj\Mixin;
 use Gdbots\Pbj\Schema;
 
 class MoreThanOneMessageForMixin extends \LogicException implements GdbotsPbjException
 {
-    /** @var Mixin */
+    /** @var string */
     private $mixin;
 
     /** @var Schema[] */
     private $schemas;
 
     /**
-     * @param Mixin $mixin
+     * @param string   $mixin
      * @param Schema[] $schemas
      */
-    public function __construct(Mixin $mixin, array $schemas)
+    public function __construct(string $mixin, array $schemas)
     {
         $this->mixin = $mixin;
         $this->schemas = $schemas;
-        $ids = array_map(function(Schema $schema) {
+        $ids = array_map(function (Schema $schema) {
             return $schema->getId()->toString() . ' => ' . $schema->getClassName();
         }, $schemas);
         parent::__construct(
             sprintf(
                 'MessageResolver returned multiple messages using [%s] when one was expected.  ' .
                 'Messages found:' . PHP_EOL . '%s',
-                $mixin->getId()->getCurieMajor(),
+                $mixin,
                 implode(PHP_EOL, $ids)
             )
         );
     }
 
     /**
-     * @return Mixin
+     * @return string
      */
-    public function getMixin()
+    public function getMixin(): string
     {
         return $this->mixin;
     }
@@ -45,7 +44,7 @@ class MoreThanOneMessageForMixin extends \LogicException implements GdbotsPbjExc
     /**
      * @return Schema[]
      */
-    public function getSchemas()
+    public function getSchemas(): array
     {
         return $this->schemas;
     }

--- a/src/Exception/NoMessageForMixin.php
+++ b/src/Exception/NoMessageForMixin.php
@@ -2,31 +2,24 @@
 
 namespace Gdbots\Pbj\Exception;
 
-use Gdbots\Pbj\Mixin;
-
 class NoMessageForMixin extends \LogicException implements GdbotsPbjException
 {
-    /** @var Mixin */
+    /** @var string */
     private $mixin;
 
     /**
-     * @param Mixin $mixin
+     * @param string $mixin
      */
-    public function __construct(Mixin $mixin)
+    public function __construct(string $mixin)
     {
         $this->mixin = $mixin;
-        parent::__construct(
-            sprintf(
-                'MessageResolver is unable to find any messages using [%s].',
-                $mixin->getId()->getCurieMajor()
-            )
-        );
+        parent::__construct(sprintf('MessageResolver is unable to find any messages using [%s].', $mixin));
     }
 
     /**
-     * @return Mixin
+     * @return string
      */
-    public function getMixin()
+    public function getMixin(): string
     {
         return $this->mixin;
     }

--- a/src/Marshaler/DynamoDb/ItemMarshaler.php
+++ b/src/Marshaler/DynamoDb/ItemMarshaler.php
@@ -61,9 +61,11 @@ final class ItemMarshaler implements Codec
             $fieldName = $field->getName();
 
             if (!$message->has($fieldName)) {
+                /*
                 if ($message->hasClearedField($fieldName)) {
                     $payload[$fieldName] = ['NULL' => true];
                 }
+                */
                 continue;
             }
 

--- a/src/Marshaler/Elastica/DocumentMarshaler.php
+++ b/src/Marshaler/Elastica/DocumentMarshaler.php
@@ -156,9 +156,11 @@ final class DocumentMarshaler implements Codec
             $fieldName = $field->getName();
 
             if (!$message->has($fieldName)) {
+                /*
                 if ($message->hasClearedField($fieldName)) {
                     $payload[$fieldName] = null;
                 }
+                */
 
                 continue;
             }

--- a/src/MessageResolver.php
+++ b/src/MessageResolver.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Gdbots\Pbj;
 
@@ -10,6 +11,31 @@ use Gdbots\Pbj\Exception\NoMessageForSchemaId;
 
 final class MessageResolver
 {
+    /**
+     * An array of all the available schemas keyed by a curie or curie major.
+     * The value is an int used to correlate with the other maps.
+     *
+     * @var int[]
+     */
+    private static $curies = [];
+
+    /**
+     * An array of all the classes, the numeric key relates to the int
+     * from the curies array.
+     *
+     * @var string[]
+     */
+    private static $classes = [];
+
+    /**
+     * An array of int[] keyed by the mixin curie. The value is a list of
+     * ints which relate to the curies that are using the mixin.
+     *
+     * @var array
+     */
+    private static $mixins = [];
+
+
     /**
      * An array of all the available class names keyed by the schema resolver key
      * and curies for resolution that is not version specific.
@@ -45,39 +71,42 @@ final class MessageResolver
     /**
      * Returns all of the registed schemas.
      *
-     * @return array
+     * @return Message[]
      */
-    public static function all()
+    public static function all(): array
     {
-        return self::$messages;
+        return self::$classes;
+    }
+
+    /**
+     * @param array $manifest
+     */
+    public static function registerManifest(array $manifest): void
+    {
+        self::$curies = $manifest['curies'] ?? [];
+        self::$classes = $manifest['classes'] ?? [];
+        self::$mixins = $manifest['mixins'] ?? [];
     }
 
     /**
      * Returns the fully qualified php class name to be used for the provided schema id.
      *
      * @param SchemaId $id
-     * @return string
+     *
+     * @return Message
+     *
      * @throws NoMessageForSchemaId
      */
-    public static function resolveId(SchemaId $id)
+    public static function resolveId(SchemaId $id): string
     {
         $curieMajor = $id->getCurieMajor();
-        if (isset(self::$resolved[$curieMajor])) {
-            return self::$resolved[$curieMajor];
-        }
-
-        if (isset(self::$messages[$curieMajor])) {
-            $className = self::$messages[$curieMajor];
-            self::$resolved[$curieMajor] = $className;
-            return $className;
+        if (isset(self::$curies[$curieMajor])) {
+            return self::$classes[self::$curies[$curieMajor]];
         }
 
         $curie = $id->getCurie()->toString();
-        if (isset(self::$messages[$curie])) {
-            $className = self::$messages[$curie];
-            self::$resolved[$curieMajor] = $className;
-            self::$resolved[$curie] = $className;
-            return $className;
+        if (isset(self::$curies[$curie])) {
+            return self::$classes[self::$curies[$curie]];
         }
 
         throw new NoMessageForSchemaId($id);
@@ -86,36 +115,35 @@ final class MessageResolver
     /**
      * Returns the fully qualified php class name to be used for the provided curie.
      *
-     * @param SchemaCurie $curie
-     * @return string
+     * @param SchemaCurie|string $curie
+     *
+     * @return Message
+     *
      * @throws NoMessageForCurie
      */
-    public static function resolveCurie(SchemaCurie $curie)
+    public static function resolveCurie($curie): string
     {
-        $key = $curie->toString();
-        if (isset(self::$resolved[$key])) {
-            return self::$resolved[$key];
+        $key = (string)$curie;
+        if (isset(self::$curies[$key])) {
+            return self::$classes[self::$curies[$key]];
         }
 
-        if (isset(self::$messages[$key])) {
-            $className = self::$messages[$key];
-            self::$resolved[$key] = $className;
-            return $className;
-        }
-
-        throw new NoMessageForCurie($curie);
+        throw new NoMessageForCurie(SchemaCurie::fromString($key));
     }
 
     /**
-     * Returns the SchemaCurie for the given SchemaQName.
+     * @param SchemaQName|string $qname
      *
-     * @param SchemaQName $qname
      * @return SchemaCurie
      *
      * @throws NoMessageForQName
      */
-    public static function resolveQName(SchemaQName $qname)
+    public static function resolveQName($qname): SchemaCurie
     {
+        if (!$qname instanceof SchemaQName) {
+            $qname = SchemaQName::fromString((string)$qname);
+        }
+
         $key = $qname->toString();
 
         if (isset(self::$resolvedQnames[$key])) {
@@ -125,10 +153,10 @@ final class MessageResolver
         $qvendor = $qname->getVendor();
         $qmessage = $qname->getMessage();
 
-        foreach (self::$messages as $id => $class) {
-            list($vendor, $package, $category, $message) = explode(':', $id);
+        foreach (self::$curies as $curie => $id) {
+            list($vendor, $package, $category, $message) = explode(':', $curie);
             if ($qvendor === $vendor && $qmessage === $message) {
-                return self::$resolvedQnames[$key] = SchemaCurie::fromString($vendor.':'.$package.':'.$category.':'.$message);
+                return self::$resolvedQnames[$key] = SchemaCurie::fromString($vendor . ':' . $package . ':' . $category . ':' . $message);
             }
         }
 
@@ -141,9 +169,18 @@ final class MessageResolver
      *
      * @param Schema $schema
      */
-    public static function registerSchema(Schema $schema)
+    public static function registerSchema(Schema $schema): void
     {
-        self::$messages[$schema->getId()->getCurieMajor()] = $schema->getClassName();
+        $nextId = count(self::$curies) + 1000;
+        self::$curies[$schema->getId()->getCurieMajor()] = $nextId;
+        self::$classes[$nextId] = $schema->getClassName();
+        foreach ($schema->getMixinIds() as $mixin) {
+            if (!isset(self::$mixins[$mixin])) {
+                self::$mixins[$mixin] = [];
+            }
+
+            self::$mixins[$mixin][] = $nextId;
+        }
     }
 
     /**
@@ -151,14 +188,14 @@ final class MessageResolver
      * @see SchemaId::getCurieMajor
      *
      * @param SchemaId|string $id
-     * @param string $className
+     * @param string          $className
      */
-    public static function register($id, $className)
+    public static function register($id, string $className): void
     {
         if ($id instanceof SchemaId) {
             $id = $id->getCurieMajor();
         }
-        self::$messages[(string) $id] = $className;
+        self::$messages[(string)$id] = $className;
     }
 
     /**
@@ -178,17 +215,18 @@ final class MessageResolver
     /**
      * Return the one schema expected to be using the provided mixin.
      *
-     * @param Mixin $mixin
+     * @param Mixin  $mixin
      * @param string $inPackage
      * @param string $inCategory
+     *
      * @return Schema
      *
      * @throws MoreThanOneMessageForMixin
      * @throws NoMessageForMixin
      */
-    public static function findOneUsingMixin(Mixin $mixin, $inPackage = null, $inCategory = null)
+    public static function findOneUsingMixin(Mixin $mixin): Schema
     {
-        $schemas = self::findAllUsingMixin($mixin, $inPackage, $inCategory);
+        $schemas = self::findAllUsingMixin($mixin);
         if (1 !== count($schemas)) {
             throw new MoreThanOneMessageForMixin($mixin, $schemas);
         }
@@ -199,36 +237,23 @@ final class MessageResolver
     /**
      * Returns an array of Schemas expected to be using the provided mixin.
      *
-     * @param Mixin $mixin
+     * @param Mixin  $mixin
      * @param string $inPackage
      * @param string $inCategory
+     *
      * @return Schema[]
      *
      * @throws NoMessageForMixin
      */
-    public static function findAllUsingMixin(Mixin $mixin, $inPackage = null, $inCategory = null)
+    public static function findAllUsingMixin(Mixin $mixin): array
     {
-        $mixinId = $mixin->getId()->getCurieMajor();
-        $key = sprintf('%s%s%s', $mixinId, $inPackage, $inCategory);
+        $key = $mixin->getId()->getCurieMajor();
 
         if (!isset(self::$resolvedMixins[$key])) {
-            $filtered = !empty($inPackage) || !empty($inCategory);
-            /** @var Message $class */
             $schemas = [];
-            foreach (self::$messages as $id => $class) {
-                if ($filtered) {
-                    list($vendor, $package, $category, $message) = explode(':', $id);
-                    if (!empty($inPackage) && $package != $inPackage) {
-                        continue;
-                    }
-                    if (!empty($inCategory) && $category != $inCategory) {
-                        continue;
-                    }
-                }
-
-                $schema = $class::schema();
-                if ($schema->hasMixin($mixinId)) {
-                    $schemas[] = $schema;
+            foreach ((self::$mixins[$key] ?? []) as $id) {
+                if (isset(self::$classes[$id])) {
+                    $schemas[] = self::$classes[$id]::schema();
                 }
             }
             self::$resolvedMixins[$key] = $schemas;

--- a/src/MessageResolver.php
+++ b/src/MessageResolver.php
@@ -258,13 +258,9 @@ final class MessageResolver
         if (!isset(self::$resolvedMixins[$key])) {
             $schemas = [];
             foreach ((self::$mixins[$key] ?? []) as $id) {
-                if (isset(self::$classes[$id])) {
-                    /** @var Schema $schema */
-                    $schema = self::$classes[$id]::schema();
-                    $schemas[$schema->getCurieMajor()] = $schema;
-                }
+                $schemas[] = self::$classes[$id]::schema();
             }
-            self::$resolvedMixins[$key] = array_values($schemas);
+            self::$resolvedMixins[$key] = $schemas;
         }
 
         if (empty(self::$resolvedMixins[$key])) {

--- a/src/Mixin.php
+++ b/src/Mixin.php
@@ -26,20 +26,14 @@ interface Mixin
     /**
      * Shortcut to resolving a mixin to one concrete schema.
      *
-     * @param string $inPackage
-     * @param string $inCategory
-     *
      * @return Schema
      */
-    public static function findOne($inPackage = null, $inCategory = null);
+    public static function findOne();
 
     /**
      * Shortcut to resolving a mixin to all concrete schemas.
      *
-     * @param string $inPackage
-     * @param string $inCategory
-     *
      * @return Schema[]
      */
-    public static function findAll($inPackage = null, $inCategory = null);
+    public static function findAll();
 }

--- a/src/Serializer/PhpArraySerializer.php
+++ b/src/Serializer/PhpArraySerializer.php
@@ -157,15 +157,18 @@ class PhpArraySerializer implements Serializer, Codec
         $message->validate();
 
         $payload = [];
-        $includeAllFields = isset($this->options['includeAllFields']) && true === $this->options['includeAllFields'];
+        // $includeAllFields = isset($this->options['includeAllFields']) && true === $this->options['includeAllFields'];
 
         foreach ($schema->getFields() as $field) {
             $fieldName = $field->getName();
 
             if (!$message->has($fieldName)) {
+                // suspect this may not be needed at all.
+                /*
                 if ($includeAllFields || $message->hasClearedField($fieldName)) {
                     $payload[$fieldName] = null;
                 }
+                */
 
                 continue;
             }


### PR DESCRIPTION
* Optimize the `MessageResolver` by using a manifest with all of the classes and mixins so no messages have to be instantiated when using `findOneUsingMixin` or `findAllUsingMixin` to find out if they have the given mixin.
* Comment out the logic that includes fields on serialized or marshaled objects when field is null.