### PR TITLE
v3.1.0

### DIFF
--- a/CHANGELOG-3.x.md
+++ b/CHANGELOG-3.x.md
@@ -2,6 +2,12 @@
 This changelog references the relevant changes done in 3.x versions.
 
 
+## v3.1.0
+* Require php `>=8.1`
+* Fix issue with use of static variables in functions for flyweight classes. https://wiki.php.net/rfc/static_variable_inheritance
+* Add return types to squash php8.1 warnings.
+
+
 ## v3.0.7
 * In `AbstractMessage` ensure decoded values are properly unset whenever array-like field values are changed.
 

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "type": "library",
   "license": "Apache-2.0",
   "require": {
-    "php": ">=7.4",
+    "php": ">=8.1",
     "ext-bcmath": "*",
     "ext-json": "*",
     "beberlei/assert": "^3.2",

--- a/src/AbstractMessage.php
+++ b/src/AbstractMessage.php
@@ -12,6 +12,8 @@ use Gdbots\Pbj\WellKnown\NodeRef;
 
 abstract class AbstractMessage implements Message, \JsonSerializable
 {
+    /** @var Schema[] */
+    private static array $schemas = [];
     private static ?PhpArraySerializer $serializer = null;
     protected array $data = [];
     protected array $decoded = [];
@@ -31,13 +33,12 @@ abstract class AbstractMessage implements Message, \JsonSerializable
 
     final public static function schema(): Schema
     {
-        static $schema;
-
-        if (null === $schema) {
-            $schema = static::defineSchema();
+        $class = static::class;
+        if (!isset(self::$schemas[$class])) {
+            self::$schemas[$class] = static::defineSchema();
         }
 
-        return $schema;
+        return self::$schemas[$class];
     }
 
     abstract protected static function defineSchema(): Schema;
@@ -66,7 +67,7 @@ abstract class AbstractMessage implements Message, \JsonSerializable
         return json_encode($this, JSON_PRETTY_PRINT);
     }
 
-    final public function jsonSerialize()
+    final public function jsonSerialize(): array
     {
         return $this->toArray();
     }

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -78,10 +78,7 @@ abstract class Enum implements \JsonSerializable
         return array_flip(static::values())[$this->value];
     }
 
-    /**
-     * @return int|string
-     */
-    final public function getValue()
+    final public function getValue(): int|string
     {
         return $this->value;
     }
@@ -91,7 +88,7 @@ abstract class Enum implements \JsonSerializable
         return (string)$this->value;
     }
 
-    final public function jsonSerialize()
+    final public function jsonSerialize(): int|string
     {
         return $this->value;
     }

--- a/src/Field.php
+++ b/src/Field.php
@@ -405,7 +405,7 @@ final class Field implements \JsonSerializable
         ];
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->toArray();
     }

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -71,7 +71,7 @@ final class Schema implements \JsonSerializable
         ];
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->toArray();
     }

--- a/src/SchemaCurie.php
+++ b/src/SchemaCurie.php
@@ -90,7 +90,7 @@ final class SchemaCurie implements \JsonSerializable
         return $this->curie;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         return $this->toString();
     }

--- a/src/SchemaId.php
+++ b/src/SchemaId.php
@@ -137,7 +137,7 @@ final class SchemaId implements \JsonSerializable
         return $this->id;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         return $this->toString();
     }

--- a/src/SchemaQName.php
+++ b/src/SchemaQName.php
@@ -84,7 +84,7 @@ final class SchemaQName implements \JsonSerializable
         return $this->qname;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         return $this->toString();
     }

--- a/src/SchemaVersion.php
+++ b/src/SchemaVersion.php
@@ -82,7 +82,7 @@ final class SchemaVersion implements \JsonSerializable
         return $this->version;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         return $this->toString();
     }

--- a/src/Type/AbstractType.php
+++ b/src/Type/AbstractType.php
@@ -8,6 +8,8 @@ use Gdbots\Pbj\Util\StringUtil;
 
 abstract class AbstractType implements Type
 {
+    /** @var self[] */
+    private static array $instances = [];
     private TypeName $typeName;
 
     /**
@@ -22,14 +24,14 @@ abstract class AbstractType implements Type
 
     final public static function create(): self
     {
-        static $instance;
-        if (null === $instance) {
+        $class = static::class;
+        if (!isset(self::$instances[$class])) {
             $a = explode('\\', static::class);
             $typeName = StringUtil::toSlugFromCamel(str_replace('Type', '', end($a)));
-            $instance = new static(TypeName::create($typeName));
+            self::$instances[$class] = new static(TypeName::create($typeName));
         }
 
-        return $instance;
+        return self::$instances[$class];
     }
 
     final public function getTypeName(): TypeName

--- a/src/WellKnown/DatedSlugIdentifier.php
+++ b/src/WellKnown/DatedSlugIdentifier.php
@@ -55,7 +55,7 @@ abstract class DatedSlugIdentifier implements Identifier
         return $this->toString();
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         return $this->toString();
     }

--- a/src/WellKnown/DynamicField.php
+++ b/src/WellKnown/DynamicField.php
@@ -163,7 +163,7 @@ final class DynamicField implements \JsonSerializable
         return ['name' => $this->name, $this->kind => $field->getType()->encode($this->value, $field)];
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->toArray();
     }

--- a/src/WellKnown/GeoPoint.php
+++ b/src/WellKnown/GeoPoint.php
@@ -52,7 +52,7 @@ final class GeoPoint implements \JsonSerializable
         return ['type' => 'Point', 'coordinates' => [$this->longitude, $this->latitude]];
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->toArray();
     }

--- a/src/WellKnown/MessageRef.php
+++ b/src/WellKnown/MessageRef.php
@@ -71,7 +71,7 @@ final class MessageRef implements \JsonSerializable
         return ['curie' => $this->curie->toString(), 'id' => $this->id];
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->toArray();
     }

--- a/src/WellKnown/Microtime.php
+++ b/src/WellKnown/Microtime.php
@@ -139,7 +139,7 @@ final class Microtime implements \JsonSerializable
         return (string)$this->int;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         return $this->toString();
     }

--- a/src/WellKnown/NodeRef.php
+++ b/src/WellKnown/NodeRef.php
@@ -103,7 +103,7 @@ final class NodeRef implements Identifier
         return $this->toString();
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         return $this->toString();
     }

--- a/src/WellKnown/SlugIdentifier.php
+++ b/src/WellKnown/SlugIdentifier.php
@@ -41,7 +41,7 @@ abstract class SlugIdentifier implements Identifier
         return $this->toString();
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         return $this->toString();
     }

--- a/src/WellKnown/StringIdentifier.php
+++ b/src/WellKnown/StringIdentifier.php
@@ -33,7 +33,7 @@ abstract class StringIdentifier implements Identifier
         return $this->toString();
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         return $this->toString();
     }

--- a/src/WellKnown/UuidIdentifier.php
+++ b/src/WellKnown/UuidIdentifier.php
@@ -43,7 +43,7 @@ class UuidIdentifier implements Identifier, GeneratesIdentifier
         return $this->toString();
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         return $this->toString();
     }


### PR DESCRIPTION
* Require php `>=8.1`
* Fix issue with use of static variables in functions for flyweight classes. https://wiki.php.net/rfc/static_variable_inheritance
* Add return types to squash php8.1 warnings.
